### PR TITLE
Fix: Change variable lookup order for qty/quantity

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ def run_strategy():
             ticker = result["ticker"]
             action = result["signal"]
             reasons = result["reasons"]
-            qty = result.get("quantity", 1)
+            qty = result.get("qty", result.get("quantity", 1))
 
             # 5. Execute trade and get execution price
             price = execute_trade(ticker, action, qty, reasons)


### PR DESCRIPTION
## Problem
- signals.py returns "qty" but main.py was looking for "quantity" first
- This caused bot to trade 0 shares instead of 10

## Solution  
- Changed line 22 in main.py to check "qty" first, then "quantity"
- Bot will now trade 10 shares of UVXY at 3:55 PM

## Testing
- Verified syntax in PyCharm
- Ready for deployment to VPS